### PR TITLE
Add RW permission to accel for group in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,13 @@ ls -l /dev/accel/
 
 # Change group for accel device
 sudo chown root:render /dev/accel/accel0
+
+# Allow to read/write from device for group
+chmod g+rw /dev/accel/accel0
+
+# Check final permissions
+$ ls -lah /dev/accel/accel0
+crw-rw---- 1 root render 261, 0 Jan 31 15:58 /dev/accel/accel0
 ```
 
 * Compilation issue


### PR DESCRIPTION
Added missing steps that add read/write access for group to /dev/accel/accel0 to FAQ section about permissions