### PR TITLE
Resolve compilation errors

### DIFF
--- a/umd/level_zero_driver/ext/source/graph/vcl_symbols.hpp
+++ b/umd/level_zero_driver/ext/source/graph/vcl_symbols.hpp
@@ -7,6 +7,7 @@
 
 #include <dlfcn.h>
 #include <memory>
+#include <array>
 
 #include "vpux_driver_compiler.h"
 #include "vpu_driver/source/utilities/log.hpp"

--- a/umd/vpu_driver/include/umd_common.hpp
+++ b/umd/vpu_driver/include/umd_common.hpp
@@ -12,6 +12,7 @@
 #include <stdexcept>
 #include <type_traits>
 #include <typeinfo>
+#include <cstdint>
 
 template <class To, class From>
 To safe_cast(From x) {


### PR DESCRIPTION
systemos:Ubuntu 22.04

error 1：
linux-npu-driver/umd/vpu_driver/include/umd_common.hpp:39:33: error: ‘uint64_t’ does not name a type
   39 |             if (x > static_cast<uint64_t>(std::numeric_limits<To>::max())) {
      |                                 ^~~~~~~~
linux-npu-driver/umd/vpu_driver/include/umd_common.hpp:13:1: note: ‘uint64_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?

error 2：
linux-npu-driver/umd/level_zero_driver/ext/source/graph/vcl_symbols.hpp:99:33: error: field ‘compilerNames’ has incomplete type ‘std::array<const char*, 2>’
   99 |     std::array<const char *, 2> compilerNames = {libvpux_driver_compiler.so,
      |                                 ^~~~~~~~~~~~~