### PR TITLE
Fix the compilation warning when using gcc-13

### DIFF
--- a/umd/level_zero_driver/ext/source/graph/vcl_symbols.hpp
+++ b/umd/level_zero_driver/ext/source/graph/vcl_symbols.hpp
@@ -5,11 +5,12 @@
  *
  */
 
-#include <dlfcn.h>
-#include <memory>
-
 #include "vpux_driver_compiler.h"
 #include "vpu_driver/source/utilities/log.hpp"
+
+#include <array>
+#include <dlfcn.h>
+#include <memory>
 
 class Vcl {
   public:

--- a/umd/vpu_driver/include/umd_common.hpp
+++ b/umd/vpu_driver/include/umd_common.hpp
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <limits>
 #include <linux/kernel.h>
 #include <stdexcept>

--- a/validation/umd-test/umd_prime_buffers.h
+++ b/validation/umd-test/umd_prime_buffers.h
@@ -6,12 +6,17 @@
  */
 
 #pragma once
+
+#include "umd_test.h"
+
 #include <fcntl.h>
-#include <linux/kernel.h>
 #include <linux/dma-buf.h>
 #include <linux/dma-heap.h>
+#include <linux/kernel.h>
+#include <stdint.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
+#include <unistd.h>
 
 #define ALLIGN_TO_PAGE(x) __ALIGN_KERNEL((x), (UmdTest::PAGE_SIZE))
 
@@ -60,7 +65,7 @@ class PrimeBufferHelper {
             return false;
 
         bufferFd = heapAlloc.fd;
-        buffers.insert({heapAlloc.fd, {size, nullptr}});
+        buffers.insert({static_cast<int>(heapAlloc.fd), {size, nullptr}});
         return true;
     }
 

--- a/validation/umd-test/utilities/data_handle.h
+++ b/validation/umd-test/utilities/data_handle.h
@@ -6,6 +6,7 @@
  */
 
 #include <linux/kernel.h>
+#include <stdint.h>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
Added missing headers. Fixed compilation error about casting from
unsigned to signed int.
