### PR TITLE
Add missing import to fix build

### DIFF
--- a/umd/vpu_driver/include/umd_common.hpp
+++ b/umd/vpu_driver/include/umd_common.hpp
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cstdint>
 #include <limits>
 #include <linux/kernel.h>


### PR DESCRIPTION
Would fail like:

```
/home/zoid/clone/linux-npu-driver/umd/vpu_driver/source/command/vpu_command.cpp: In member function ‘void VPU::VPUCommand::appendAssociateBufferObject(VPU::VPUBufferObject*)’:
/home/zoid/clone/linux-npu-driver/umd/vpu_driver/source/command/vpu_command.cpp:126:20: error: ‘find’ is not a member of ‘std’; did you mean ‘bind’?
  126 |     auto it = std::find(bufferObjects.begin(), bufferObjects.end(), bo);
      |                    ^~~~
      |                    bind
```