### PR TITLE
Fix compilation failure with GCC-14

### DIFF
--- a/umd/level_zero_driver/core/source/event/event.cpp
+++ b/umd/level_zero_driver/core/source/event/event.cpp
@@ -14,6 +14,7 @@
 
 #include <level_zero/ze_api.h>
 #include <thread>
+#include <algorithm>
 
 namespace L0 {
 

--- a/umd/level_zero_driver/ext/source/graph/elf_parser.cpp
+++ b/umd/level_zero_driver/ext/source/graph/elf_parser.cpp
@@ -21,6 +21,7 @@
 #include <vpux_headers/metadata.hpp>
 #include <vpux_elf/types/vpu_extensions.hpp>
 #include <vpux_elf/utils/error.hpp>
+#include <algorithm>
 
 namespace L0 {
 

--- a/umd/level_zero_driver/tools/source/metrics/metric.cpp
+++ b/umd/level_zero_driver/tools/source/metrics/metric.cpp
@@ -7,6 +7,7 @@
 
 #include "level_zero_driver/tools/source/metrics/metric.hpp"
 #include "vpu_driver/source/utilities/log.hpp"
+#include <algorithm>
 
 namespace L0 {
 

--- a/umd/vpu_driver/source/command/vpu_command.cpp
+++ b/umd/vpu_driver/source/command/vpu_command.cpp
@@ -14,6 +14,7 @@
 #include <cstdint>
 #include <vector>
 #include <map>
+#include <algorithm>
 
 namespace VPU {
 

--- a/umd/vpu_driver/source/command/vpu_command_buffer.cpp
+++ b/umd/vpu_driver/source/command/vpu_command_buffer.cpp
@@ -11,6 +11,7 @@
 #include "vpu_driver/source/command/vpu_command_buffer.hpp"
 #include "vpu_driver/source/command/vpu_copy_command.hpp"
 #include "vpu_driver/source/utilities/log.hpp"
+#include <algorithm>
 
 namespace VPU {
 


### PR DESCRIPTION
umd/level_zero_driver/core/source/event/event.cpp:65:31: error: 'remove_if' is not a member of 'std'; did you mean 'remove_cv'?
|    65 |     associatedJobs.erase(std::remove_if(associatedJobs.begin(),
|       |                               ^~~~~~~~~
|       |                               remove_cv

| umd/vpu_driver/source/command/vpu_command.cpp: In member function 'void VPU::VPUCommand::appendAssociateBufferObject(VPU::VPUBufferObject*)': | umd/vpu_driver/source/command/vpu_command.cpp:126:20: error: 'find' is not a member of 'std'; did you mean 'bind'?
|   126 |     auto it = std::find(bufferObjects.begin(), bufferObjects.end(), bo);
|       |                    ^~~~
|       |                    bind

| umd/vpu_driver/source/command/vpu_command_buffer.cpp: In member function 'bool VPU::VPUCommandBuffer::addCommand(VPU::VPUCommand*, uint64_t&, uint64_t&)': | umd/vpu_driver/source/command/vpu_command_buffer.cpp:185:24: error: 'find' is not a member of 'std'; did you mean 'bind'?
|   185 |         auto it = std::find(bufferHandles.begin(), bufferHandles.end(), bo->getHandle());
|       |                        ^~~~
|       |                        bind

| umd/level_zero_driver/ext/source/graph/elf_parser.cpp:301:32: error: 'max_element' is not a member of 'std'; did you mean 'tuple_element'?
|   301 |                           std::max_element(stride_begin + TENSOR_5D_STRIDE_C, stride_end));
|       |                                ^~~~~~~~~~~
|       |                                tuple_element
| umd/level_zero_driver/ext/source/graph/elf_parser.cpp:315:37: error: 'max_element' is not a member of 'std'; did you mean 'tuple_element'?
|   315 |         auto max_stride_val = *std::max_element(stride_begin + TENSOR_4D_STRIDE_C, stride_end);
|       |                                     ^~~~~~~~~~~

| umd/level_zero_driver/tools/source/metrics/metric.cpp: In member function 'void L0::MetricContext::deactivateMetricGroups(int)': | umd/level_zero_driver/tools/source/metrics/metric.cpp:275:38: error: 'remove_if' is not a member of 'std'; did you mean 'remove_cv'?
|   275 |     activatedMetricGroups.erase(std::remove_if(activatedMetricGroups.begin(),
|       |                                      ^~~~~~~~~
|       |                                      remove_cv