### PR TITLE
Fix compiler warnings from gcc-14 and clang-18

### DIFF
--- a/umd/level_zero_driver/unit_tests/source/core/cmdlist/test_cmdlist_api.cpp
+++ b/umd/level_zero_driver/unit_tests/source/core/cmdlist/test_cmdlist_api.cpp
@@ -524,7 +524,7 @@ struct CommandListEventApiTest : Test<CommandListFixture> {
         CommandListFixture::TearDown();
     }
 
-    const uint32_t evPoolCap = 5;
+    static constexpr uint32_t evPoolCap = 5;
     ze_event_pool_handle_t hEvPool = nullptr;
     ze_event_handle_t hEvent = nullptr;
 };

--- a/validation/kmd-test/kmd_test.h
+++ b/validation/kmd-test/kmd_test.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <libudev.h>
 #include <linux/kernel.h>
 #include <linux/magic.h>

--- a/validation/umd-test/test_buffers_import_gpu.cpp
+++ b/validation/umd-test/test_buffers_import_gpu.cpp
@@ -65,7 +65,7 @@ TEST_F(BuffersImport, GPUclKernelToNPUzeCopy) {
     ASSERT_EQ(CL_SUCCESS, oclResult);
 
     // create input buffer
-    size_t size = 20;
+    const size_t size = 20;
     uint8_t inputBuffer[size];
     std::iota(inputBuffer, inputBuffer + size, 1);
 
@@ -232,8 +232,8 @@ cl_platform_id getIntelOpenCLPlatform() {
     if (result != CL_SUCCESS)
         return nullptr;
 
-    cl_platform_id platforms[numPlatforms];
-    result = clGetPlatformIDs(numPlatforms, platforms, nullptr);
+    std::vector<cl_platform_id> platforms(numPlatforms, 0);
+    result = clGetPlatformIDs(numPlatforms, platforms.data(), nullptr);
     if (result != CL_SUCCESS)
         return nullptr;
 
@@ -243,12 +243,12 @@ cl_platform_id getIntelOpenCLPlatform() {
         if (result != CL_SUCCESS)
             return nullptr;
 
-        char vendor[size + 1];
-        result = clGetPlatformInfo(platforms[i], CL_PLATFORM_VENDOR, size, vendor, nullptr);
+        std::vector<char> vendor(size + 1, 0);
+        result = clGetPlatformInfo(platforms[i], CL_PLATFORM_VENDOR, size, vendor.data(), nullptr);
         if (result != CL_SUCCESS)
             return nullptr;
 
-        if (std::string(vendor) == "Intel(R) Corporation") {
+        if (std::string(vendor.data()) == "Intel(R) Corporation") {
             return platforms[i];
         }
     }


### PR DESCRIPTION
The gcc-14 reports about missing "algorithm" header in kmd_test.h. The plain clang-18 reports about usage of variable-length arrays (VLA) extension from C99 standard that is not recommended in C++ code