### PR TITLE
Return early in read_os_release if unable to find a field in os-release

### DIFF
--- a/cmake/detect_linux_system.cmake
+++ b/cmake/detect_linux_system.cmake
@@ -19,6 +19,7 @@ function(read_os_release ENTRY VAR_OUTPUT)
   file(STRINGS ${OS_RELEASE_PATH} OUTPUT REGEX ^${ENTRY}=.* )
   if (NOT OUTPUT)
     message(WARNING "Could not find '${ENTRY}=.*' pattern in ${OS_RELEASE_PATH}")
+    return()
   endif()
 
   string(REGEX REPLACE "${ENTRY}=" "" OUTPUT ${OUTPUT})


### PR DESCRIPTION
Partially fixes https://github.com/intel/linux-npu-driver/issues/55