### PR TITLE
NPU Driver 1.10.1 release - hotfix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24")
     cmake_policy(SET CMP0135 NEW)
 endif()
 
-set(STACK_VERSION 1.10.0 CACHE STRING "Main project version")
+set(STACK_VERSION 1.10.1 CACHE STRING "Main project version")
 project(npu-linux-driver VERSION ${STACK_VERSION})
 
 set(BUILD_NUMBER "dev-0" CACHE STRING "Build number composed of name and unique number used as driver version")

--- a/compiler/compiler_source.cmake
+++ b/compiler/compiler_source.cmake
@@ -18,8 +18,8 @@ include(ExternalProject)
 
 # OpenVINO + NPU Plugin package options
 set(OPENVINO_REVISION 0ebff040fd22daa37612a82fdf930ffce4ebb099)
-set(VPUX_PLUGIN_REVISION 4f89b7c000d98bb8f4bf5bb058967bbd02834caa)
-set(VPUX_PLUGIN_RELEASE npu_ud_2024_44_rc1)
+set(VPUX_PLUGIN_REVISION 150e2025aaba8bcc0f0e3853a526ee2e1e2e32a7)
+set(VPUX_PLUGIN_RELEASE npu_ud_2024_44_rc2)
 set(OPENCV_REVISION 78195bc3dfe20b96e721ae8b32d0aa3491755e78)
 
 # Directories
@@ -46,7 +46,7 @@ ExternalProject_Add(
 ExternalProject_Add(
   npu_plugin_source
   GIT_REPOSITORY
-    https://github.com/openvinotoolkit/npu_plugin.git
+    https://github.com/openvinotoolkit/npu_compiler.git
   GIT_TAG ${VPUX_PLUGIN_REVISION}
   PREFIX ${NPU_PLUGIN_PREFIX_DIR}
   SOURCE_DIR ${NPU_PLUGIN_SOURCE_DIR}

--- a/umd/level_zero_driver/core/source/memory/memory.cpp
+++ b/umd/level_zero_driver/core/source/memory/memory.cpp
@@ -128,7 +128,7 @@ ze_result_t Context::getMemAllocProperties(const void *ptr,
         pMemAllocProperties->type = ZE_MEMORY_TYPE_UNKNOWN;
     }
 
-    pMemAllocProperties->id = bo->getHandle();
+    pMemAllocProperties->id = bo->getId();
     pMemAllocProperties->pageSize = bo->getAllocSize();
 
     if (pMemAllocProperties->pNext &&

--- a/umd/level_zero_driver/unit_tests/source/core/memory/test_memory.cpp
+++ b/umd/level_zero_driver/unit_tests/source/core/memory/test_memory.cpp
@@ -173,7 +173,7 @@ TEST_F(ContextMemoryTestProperties, passHostMemoryAddressToGetMemPropertiesExpec
     EXPECT_EQ(pMemAllocProperties.stype, ZE_STRUCTURE_TYPE_MEMORY_ALLOCATION_PROPERTIES);
     EXPECT_EQ(pMemAllocProperties.pNext, nullptr);
     EXPECT_EQ(pMemAllocProperties.type, ZE_MEMORY_TYPE_HOST);
-    EXPECT_EQ(pMemAllocProperties.id, 0u);
+    EXPECT_GT(pMemAllocProperties.id, 0u);
     EXPECT_EQ(pMemAllocProperties.pageSize, size);
 
     context->freeMem(ptr);
@@ -194,7 +194,7 @@ TEST_F(ContextMemoryTestProperties, passDeviceMemoryAddressToGetMemPropertiesExp
     EXPECT_EQ(pMemAllocProperties.stype, ZE_STRUCTURE_TYPE_MEMORY_ALLOCATION_PROPERTIES);
     EXPECT_EQ(pMemAllocProperties.pNext, nullptr);
     EXPECT_EQ(pMemAllocProperties.type, ZE_MEMORY_TYPE_DEVICE);
-    EXPECT_EQ(pMemAllocProperties.id, 0u);
+    EXPECT_GT(pMemAllocProperties.id, 0u);
     EXPECT_EQ(pMemAllocProperties.pageSize, size);
 
     context->freeMem(ptr);

--- a/umd/vpu_driver/source/command/vpu_command.cpp
+++ b/umd/vpu_driver/source/command/vpu_command.cpp
@@ -36,8 +36,7 @@ bool VPUCommand::copyDescriptor(VPUDeviceContext *ctx, void **desc) {
               descriptor->data.end(),
               *reinterpret_cast<uint8_t **>(desc));
 
-    *descriptor->commandOffset =
-        safe_cast<uint32_t>(ctx->getBufferVPUAddress(*desc) - ctx->getVPULowBaseAddress());
+    *descriptor->commandOffset = safe_cast<uint64_t>(ctx->getBufferVPUAddress(*desc));
     *reinterpret_cast<uint8_t **>(desc) += getFwDataCacheAlign(descriptor->data.size());
 
     return true;

--- a/umd/vpu_driver/source/command/vpu_command_buffer.cpp
+++ b/umd/vpu_driver/source/command/vpu_command_buffer.cpp
@@ -154,17 +154,9 @@ bool VPUCommandBuffer::initHeader(size_t cmdSize) {
     bb->cmd_offset = offsetof(CommandHeader, commandList);
     bb->cmd_buffer_size = safe_cast<uint32_t>(bb->cmd_offset + cmdSize);
     bb->context_save_area_address = buffer->getVPUAddr() + offsetof(CommandHeader, contextSaveArea);
-
-    uint64_t baseAddress = ctx->getVPULowBaseAddress();
-    if (baseAddress == 0) {
-        LOG_E("Invalid base address for VPU");
-        return false;
-    }
-
-    bb->kernel_heap_base_address = baseAddress;
-    bb->descriptor_heap_base_address = baseAddress;
-    bb->fence_heap_base_address = baseAddress;
-
+    bb->kernel_heap_base_address = 0;
+    bb->descriptor_heap_base_address = 0;
+    bb->fence_heap_base_address = 0;
     return true;
 }
 
@@ -225,7 +217,7 @@ bool VPUCommandBuffer::setSyncFenceAddr(VPUCommand *cmd) {
     }
 
     auto *fenceSignalHeader = reinterpret_cast<const vpu_cmd_fence_t *>(cmd->getCommitStream());
-    syncFenceVpuAddr = ctx->getVPULowBaseAddress() + fenceSignalHeader->offset;
+    syncFenceVpuAddr = fenceSignalHeader->offset;
     return true;
 }
 

--- a/umd/vpu_driver/source/command/vpu_event_command.cpp
+++ b/umd/vpu_driver/source/command/vpu_event_command.cpp
@@ -50,9 +50,8 @@ VPUEventCommand::VPUEventCommand(VPUDeviceContext *ctx,
 
     cmd.header.type = cmdType;
     cmd.header.size = sizeof(vpu_cmd_fence_t);
-    cmd.offset =
-        safe_cast<uint32_t>(ctx->getBufferVPUAddress(eventHeapPtr) - ctx->getVPULowBaseAddress());
     cmd.value = eventState;
+    cmd.offset = safe_cast<uint64_t>(ctx->getBufferVPUAddress(eventHeapPtr));
     command.emplace<vpu_cmd_fence_t>(cmd);
     appendAssociateBufferObject(ctx, eventHeapPtr);
 }

--- a/umd/vpu_driver/source/device/vpu_device.cpp
+++ b/umd/vpu_driver/source/device/vpu_device.cpp
@@ -58,8 +58,9 @@ bool VPUDevice::initializeCaps(VPUDriverApi *drvApi) {
     if (drvApi->checkDeviceCapability(DRM_IVPU_CAP_DMA_MEMORY_RANGE))
         hwInfo.dmaMemoryRangeCapability = true;
 
-    jsmApiVersion = drvApi->getFWComponentVersion(hwInfo.fwJsmCmdApiVerIndex);
     mappedInferenceVersion = drvApi->getFWComponentVersion(hwInfo.fwMappedInferenceIndex);
+    jsmApiVersion = drvApi->getFWComponentVersion(hwInfo.fwJsmCmdApiVerIndex);
+
     return true;
 }
 

--- a/umd/vpu_driver/source/device/vpu_device_context.cpp
+++ b/umd/vpu_driver/source/device/vpu_device_context.cpp
@@ -137,13 +137,13 @@ VPUBufferObject *VPUDeviceContext::findBuffer(const void *ptr) const {
     const std::lock_guard<std::mutex> lock(mtx);
     auto it = trackedBuffers.lower_bound(ptr);
     if (it == trackedBuffers.end()) {
-        LOG_E("Failed to find pointer %p in device context!", ptr);
+        LOG(DEVICE, "Failed to find pointer %p in device context!", ptr);
         return nullptr;
     }
 
     auto &bo = it->second;
     if (!bo->isInRange(ptr)) {
-        LOG_E("Pointer is not within the range");
+        LOG(DEVICE, "Pointer is not within the range");
         return nullptr;
     }
 

--- a/umd/vpu_driver/source/device/vpu_device_context.hpp
+++ b/umd/vpu_driver/source/device/vpu_device_context.hpp
@@ -113,11 +113,6 @@ class VPUDeviceContext {
         return static_cast<uint32_t>(std::bitset<32>(hwInfo->tileConfig).count());
     }
 
-    /**
-     * Return the lowest VPU address from VPU low range that is accessible by firmware device
-     */
-    uint64_t getVPULowBaseAddress() const { return hwInfo->baseLowAddress; }
-
     uint32_t getExtraDmaDescriptorSize() const { return hwInfo->extraDmaDescriptorSize; }
 
     uint64_t getFwMappedInferenceVersion() const { return hwInfo->fwMappedInferenceVersion; }

--- a/umd/vpu_driver/source/memory/vpu_buffer_object.cpp
+++ b/umd/vpu_driver/source/memory/vpu_buffer_object.cpp
@@ -32,7 +32,10 @@ VPUBufferObject::VPUBufferObject(const VPUDriverApi &drvApi,
     , basePtr(static_cast<uint8_t *>(basePtr))
     , allocSize(allocSize)
     , vpuAddr(vpuAddr)
-    , handle(handle) {}
+    , handle(handle) {
+    static uint64_t counter = 0;
+    id = ++counter;
+}
 
 VPUBufferObject::~VPUBufferObject() {
     if (drvApi.unmap(basePtr, allocSize) != 0) {

--- a/umd/vpu_driver/source/memory/vpu_buffer_object.hpp
+++ b/umd/vpu_driver/source/memory/vpu_buffer_object.hpp
@@ -144,6 +144,7 @@ class VPUBufferObject {
      *
      */
     bool exportToFd(int32_t &fd);
+    uint64_t getId() const { return id; }
 
   private:
     const VPUDriverApi &drvApi;
@@ -154,6 +155,7 @@ class VPUBufferObject {
 
     uint64_t vpuAddr;
     uint32_t handle;
+    uint64_t id;
 };
 
 } // namespace VPU

--- a/umd/vpu_driver/unit_tests/vpu_device/device_context_test.cpp
+++ b/umd/vpu_driver/unit_tests/vpu_device/device_context_test.cpp
@@ -28,10 +28,8 @@ struct DeviceContextTest : public ::testing::Test {
     void SetUp() override {
         // Make sure no other tracking buffers exist in MM.
         ASSERT_EQ(ctx->getBuffersCount(), 0u);
-
-        auto baseAddress = ctx->getVPULowBaseAddress();
-        cmdBufferHeader.kernel_heap_base_address = baseAddress;
-        cmdBufferHeader.descriptor_heap_base_address = baseAddress;
+        cmdBufferHeader.kernel_heap_base_address = 0;
+        cmdBufferHeader.descriptor_heap_base_address = 0;
     }
 
     void TearDown() override {
@@ -88,10 +86,6 @@ struct DeviceContextTest : public ::testing::Test {
 
     const uint32_t allocSize = 4 * 1024;
 };
-
-TEST_F(DeviceContextTest, getVPULowBaseAddressExpectSuccess) {
-    EXPECT_NE(0u, ctx->getVPULowBaseAddress());
-}
 
 TEST_F(DeviceContextTest, createAndFreeDeviceMemoryExpectSuccess) {
     auto ptr = ctx->createDeviceMemAlloc(allocSize);


### PR DESCRIPTION
The main purpose of 1.10.1 release is to enable LLM workloads in [Lunar Lake platforms](https://ark.intel.com/content/www/us/en/ark/products/codename/213792/products-formerly-lunar-lake.html)