### PR TITLE
Nix flake packaging

### DIFF
--- a/firmware/default.nix
+++ b/firmware/default.nix
@@ -1,22 +1,35 @@
-{ lib, stdenv, stack-version, ... }:
-stdenv.mkDerivation {
-  pname = "intel-npu-linux-firmware";
-  version = stack-version;
+{
+  lib,
+  stdenvNoCC,
+  version,
+  system,
+  ...
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "intel-npu-firmware";
+  version = version;
 
   src = with lib.fileset; toSource {
-    root = ./.;
-    fileset = ./bin;
+    root = ../.;
+    fileset = unions [
+      ./bin
+      ../LICENSE.md
+    ];
   };
 
   meta = {
     homepage = "https://github.com/intel/linux-npu-driver";
     description = "Intel NPU (Neural Processing Unit) firmware";
-    platforms = [ "x86_64-linux" ];
+    platforms = [ system ];
     license = lib.licenses.mit;
   };
 
   installPhase = ''
     mkdir -p $out/lib/firmware/intel/vpu
-    cp -P bin/*.bin $out/lib/firmware/intel/vpu
+    cp -P firmware/bin/*.bin $out/lib/firmware/intel/vpu
+
+    mkdir -p $out/share/doc/intel-npu-driver
+    cp LICENSE.md $out/share/doc/intel-npu-driver/LICENSE
   '';
 }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1739866667,
+        "narHash": "sha256-EO1ygNKZlsAC9avfcwHkKGMsmipUk1Uc0TbrEZpkn64=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "73cf49b8ad837ade2de76f87eb53fc85ed5d4680",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -3,17 +3,27 @@
 
   inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
 
-  outputs = { self, nixpkgs, ... } @ inputs:
-  with builtins;
-  let
+  outputs = {
+    self,
+    nixpkgs,
+    ...
+  } @ inputs: let
+    system = "x86_64-linux";
     lib = nixpkgs.lib;
-    pkgs = nixpkgs.legacyPackages.x86_64-linux;
-    extract-version = match "set\\(STACK_VERSION ([\\.0-9]+) .+\\)";
-    lines = lib.splitString "\n" (readFile ./CMakeLists.txt);
-    stack-version = elemAt (
-      lib.findFirst isList null (map extract-version lines)
+    pkgs = import nixpkgs { system = system; };
+
+    version = with builtins; let
+      lines = lib.splitString "\n" (readFile ./CMakeLists.txt);
+      extract = match "set\\(STACK_VERSION ([\\.0-9]+) .+\\)";
+    in elemAt (
+      lib.findFirst isList null (map extract lines)
     ) 0;
   in {
-    firmware = pkgs.callPackage ./firmware/default.nix { inherit stack-version; };
+    packages.${system} = rec {
+      firmware = pkgs.callPackage ./firmware/default.nix {
+        inherit system version;
+      };
+      default = firmware;
+    };
   };
 }


### PR DESCRIPTION
So NixOS users can load the firmware.

# Test

On my ThinkPad X13 Yoga Gen5, good.
```
[pseudoc@zipzap:~]$ sudo dmesg | grep "intel_vpu"
[   10.404035] intel_vpu 0000:00:0b.0: enabling device (0000 -> 0002)
[   10.411564] intel_vpu 0000:00:0b.0: [drm] Firmware: intel/vpu/vpu_37xx_v0.0.bin, version: 20241025*MTL_CLIENT_SILICON-release*1830*ci_tag_ud202444_vpu_rc_20241025_1830*ae072b315bc
[   10.599330] [drm] Initialized intel_vpu 1.0.0 for 0000:00:0b.0 on minor 0
```

## My flake

https://github.com/pseudocc/nix-config/commit/27ee1af101d08326150af267cdcfabce7de4365a