### PR TITLE
Fix level-zero.cmake header glob

### DIFF
--- a/third_party/cmake/level-zero.cmake
+++ b/third_party/cmake/level-zero.cmake
@@ -37,8 +37,10 @@ endif()
 # TODO: Get rid of copying the headers if level-zero is installed
 set(LEVEL_ZERO_HEADERS_DIR "${CMAKE_BINARY_DIR}/include/level_zero")
 file(MAKE_DIRECTORY ${LEVEL_ZERO_HEADERS_DIR})
-file(GLOB LEVEL_ZERO_HEADERS
-    ${LevelZero_INCLUDE_DIRS}/*.h
-    ${LevelZero_INCLUDE_DIRS}/layers
-    ${LevelZero_INCLUDE_DIRS}/loader)
-file(COPY ${LEVEL_ZERO_HEADERS} DESTINATION ${LEVEL_ZERO_HEADERS_DIR})
+foreach(LevelZero_INCLUDE_DIR IN LISTS LevelZero_INCLUDE_DIRS)
+    file(GLOB LEVEL_ZERO_HEADERS
+        ${LevelZero_INCLUDE_DIR}/*.h
+        ${LevelZero_INCLUDE_DIR}/layers
+        ${LevelZero_INCLUDE_DIR}/loader)
+    file(COPY ${LEVEL_ZERO_HEADERS} DESTINATION ${LEVEL_ZERO_HEADERS_DIR})
+endforeach()


### PR DESCRIPTION
I've run into build issues with `intel-npu-driver` on NixOS, these were caused by a broken glob expression in `third_party/cmake/level_zero.cmake`, which doesn't work if `LevelZero_INCLUDE_DIRS` includes multiple paths.

A simple solution would be to just loop over `LevelZero_INCLUDE_DIRS` and do the glob for each dir separately.