### PR TITLE
Fix for missing CL/cl.h and remove redundant build dependencies

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -170,7 +170,7 @@ ls /dev/accel/accel0
 Install the required dependencies in Ubuntu:
 ```
 sudo apt update
-sudo apt install -y build-essential git git-lfs cmake libudev-dev libboost-all-dev libssl-dev libudev-dev
+sudo apt install -y build-essential git git-lfs cmake python3
 ```
 
 Commands to build the driver:

--- a/validation/umd-test/CMakeLists.txt
+++ b/validation/umd-test/CMakeLists.txt
@@ -62,9 +62,9 @@ if (TARGET opencv_core AND TARGET opencv_imgcodecs)
     target_compile_definitions(${PROJECT_NAME} PRIVATE UMD_TESTS_USE_OPENCV)
 endif()
 
-if (OpenCL_FOUND)
+if (TARGET OpenCL::OpenCL)
     target_sources(${PROJECT_NAME} PRIVATE test_external_memory_opencl.cpp)
-    target_link_libraries(${PROJECT_NAME} OpenCL)
+    target_link_libraries(${PROJECT_NAME} OpenCL::OpenCL)
 endif()
 
 target_compile_options(${PROJECT_NAME} PRIVATE -DVPU_GTEST_APP -Wall -Wextra -Werror)


### PR DESCRIPTION
Reduced the required build dependencies for Ubuntu to
```
build-essential git git-lfs cmake python3
```

Python3 is required by LLVM used in npu_compiler repository. Removed
unused openssl, udev and boost dependencies.

Used target to check if OpenCL is present in the system. This fixes an
issue with incorrectly found OpenCL by find_package(OpenCL) which
previously returned false positive results.