### PR TITLE
Remove link to Intel NPU Acceleration Library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <!---
 
-Copyright (C) 2022-2024 Intel Corporation
+Copyright (C) 2022-2025 Intel Corporation
 
 SPDX-License-Identifier: MIT
 


### PR DESCRIPTION
Removed link to Intel NPU Acceleration library documentation because intel/intel-npu-acceleration-library repository has been archived