### PR TITLE
Disable building OpenCV with Java support

### DIFF
--- a/compiler/openvino_build.cmake
+++ b/compiler/openvino_build.cmake
@@ -153,6 +153,7 @@ ExternalProject_Add(
     -DOPENCV_GENERATE_SETUPVARS=ON
     -DBUILD_opencv_python3=OFF
     -DBUILD_opencv_dnn=OFF
+    -DBUILD_opencv_java=OFF
     -DWITH_EIGEN=OFF
     -DWITH_JASPER=OFF
     -DWITH_OPENCL=OFF


### PR DESCRIPTION
The OpenVINO apps used in Linux NPU driver validation does not requires OpenCV with Java