### PR TITLE
Add find package gtest and yaml-cpp package

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022-2024 Intel Corporation
+# Copyright (C) 2022-2026 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 #

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -14,9 +14,6 @@ if (ENABLE_NPU_PERFETTO_BUILD)
   include(cmake/perfetto.cmake)
 endif()
 
-set(INSTALL_GTEST OFF)
-add_subdirectory(googletest EXCLUDE_FROM_ALL)
+include(cmake/googletest.cmake)
+include(cmake/yaml-cpp.cmake)
 
-set(YAML_CPP_INSTALL OFF)
-set(BUILD_SHARED_LIBS OFF)
-add_subdirectory(yaml-cpp EXCLUDE_FROM_ALL)

--- a/third_party/cmake/googletest.cmake
+++ b/third_party/cmake/googletest.cmake
@@ -1,0 +1,52 @@
+#
+# Copyright (C) 2022-2024 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+#
+
+# Try to find system-installed GoogleTest package
+# Package names vary by distribution:
+# - Fedora/RHEL/openSUSE Tumbleweed: gtest-devel (provides gmock-devel as well)
+# - Ubuntu/Debian: libgtest-dev
+find_package(GTest QUIET)
+
+if(NOT GTest_FOUND)
+  message(STATUS "System GoogleTest not found, building from submodule")
+  set(INSTALL_GTEST OFF)
+  add_subdirectory(googletest EXCLUDE_FROM_ALL)
+else()
+  message(STATUS "  Found gtest, version ${GTest_VERSION}")
+  # Display include directories and library paths for each target
+  if(TARGET GTest::gtest)
+    get_target_property(GTEST_INCLUDE_DIRS GTest::gtest INTERFACE_INCLUDE_DIRECTORIES)
+    get_target_property(GTEST_LOCATION GTest::gtest LOCATION)
+    message(STATUS "GTest_INCLUDE_DIRS	: ${GTEST_INCLUDE_DIRS}")
+    message(STATUS "GTest_LIBRARIES	: ${GTEST_LOCATION}")
+    message(STATUS "GTest_VERSION	: ${GTest_VERSION}")
+  endif()
+
+  if(TARGET GTest::gmock)
+    get_target_property(GMOCK_INCLUDE_DIRS GTest::gmock INTERFACE_INCLUDE_DIRECTORIES)
+    get_target_property(GMOCK_LOCATION GTest::gmock LOCATION)
+    message(STATUS "GMock_INCLUDE_DIRS	: ${GMOCK_INCLUDE_DIRS}")
+    message(STATUS "GMock_LIBRARIES	: ${GMOCK_LOCATION}")
+    message(STATUS "GMock_VERSION	: ${GTest_VERSION}")
+  endif()
+
+  # Create aliases for consistency with submodule build
+  # The submodule provides 'gtest' and 'gmock' targets
+  # System package provides 'GTest::gtest', 'GTest::gmock', etc.
+  if(NOT TARGET gtest)
+    add_library(gtest ALIAS GTest::gtest)
+  endif()
+  if(NOT TARGET gmock)
+    add_library(gmock ALIAS GTest::gmock)
+  endif()
+  if(NOT TARGET gtest_main AND TARGET GTest::gtest_main)
+    add_library(gtest_main ALIAS GTest::gtest_main)
+  endif()
+  if(NOT TARGET gmock_main AND TARGET GTest::gmock_main)
+    add_library(gmock_main ALIAS GTest::gmock_main)
+  endif()
+endif()
+

--- a/third_party/cmake/googletest.cmake
+++ b/third_party/cmake/googletest.cmake
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022-2024 Intel Corporation
+# Copyright (C) 2022-2026 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 #

--- a/third_party/cmake/yaml-cpp.cmake
+++ b/third_party/cmake/yaml-cpp.cmake
@@ -1,0 +1,19 @@
+#
+# Copyright (C) 2022-2024 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+#
+
+# Try to find system-installed yaml-cpp package
+# Package names vary by distribution:
+# - Fedora/RHEL/openSUSE Tumbleweed: yaml-cpp-devel
+# - Ubuntu/Debian: libyaml-cpp-dev
+find_package(yaml-cpp QUIET)
+
+if(NOT yaml-cpp_FOUND)
+  message(STATUS "System yaml-cpp not found, building from submodule")
+  set(YAML_CPP_INSTALL OFF)
+  set(BUILD_SHARED_LIBS OFF)
+  add_subdirectory(yaml-cpp EXCLUDE_FROM_ALL)
+endif()
+

--- a/third_party/cmake/yaml-cpp.cmake
+++ b/third_party/cmake/yaml-cpp.cmake
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022-2024 Intel Corporation
+# Copyright (C) 2022-2026 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 #


### PR DESCRIPTION
- Check gtest, yaml-cpp package installed in system-wide distribution
- Package gtest, yaml-cpp could not be found will rollback to submodules

Package name variation between distributions
Fedora/Red Hat/suse: gtest-devel (provides gmock-devel as well), yaml-cpp-devel
Ubuntu/Debian: libgtest-dev, libyaml-cpp-dev

sample output from cmake logs:
-- Found PkgConfig: /usr/bin/pkg-config (found version "2.5.1")
-- Checking for module 'level-zero>=1.27.0'
--   Found level-zero, version 1.28.6
-- LevelZero_INCLUDE_DIRS: /usr/lib64/pkgconfig/../../include/level_zero;/usr/lib64/pkgconfig/../../include
-- LevelZero_LIBRARIES:    ze_loader
-- LevelZero_VERSION:      1.28.6
--   Found gtest, version 1.17.0
-- GTest_INCLUDE_DIRS : /usr/include
-- GTest_LIBRARIES    : /usr/lib64/libgtest.so.1.17.0
-- GTest_VERSION      : 1.17.0
-- GMock_INCLUDE_DIRS : /usr/include
-- GMock_LIBRARIES    : /usr/lib64/libgmock.so.1.17.0
-- GMock_VERSION      : 1.17.0
-- Level Zero driver version: 1779062400
-- Configuring done (3.7s)
-- Generating done (0.1s)