### PR TITLE
cmake: Add options to force building third-party deps from submodules

### DIFF
--- a/third_party/cmake/googletest.cmake
+++ b/third_party/cmake/googletest.cmake
@@ -4,11 +4,15 @@
 # SPDX-License-Identifier: MIT
 #
 
+option(ENABLE_GOOGLETEST_FROM_SUBMODULE "Force building GoogleTest from submodule" OFF)
+
 # Try to find system-installed GoogleTest package
 # Package names vary by distribution:
 # - Fedora/RHEL/openSUSE Tumbleweed: gtest-devel (provides gmock-devel as well)
 # - Ubuntu/Debian: libgtest-dev
-find_package(GTest QUIET)
+if(NOT ENABLE_GOOGLETEST_FROM_SUBMODULE)
+  find_package(GTest QUIET)
+endif()
 
 if(NOT GTest_FOUND)
   message(STATUS "System GoogleTest not found, building from submodule")

--- a/third_party/cmake/level-zero.cmake
+++ b/third_party/cmake/level-zero.cmake
@@ -2,13 +2,18 @@
 #
 # SPDX-License-Identifier: MIT
 
+option(ENABLE_LEVEL_ZERO_FROM_SUBMODULE "Force building Level Zero from submodule" OFF)
+
 include(FetchContent)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 set(LEVEL_ZERO_VERSION "1.27.0")
 
-find_package(LevelZero ${LEVEL_ZERO_VERSION})
-if(NOT LevelZero_FOUND
+if(NOT ENABLE_LEVEL_ZERO_FROM_SUBMODULE)
+  find_package(LevelZero ${LEVEL_ZERO_VERSION})
+endif()
+if(NOT ENABLE_LEVEL_ZERO_FROM_SUBMODULE
+   AND NOT LevelZero_FOUND
    AND LINUX_SYSTEM_NAME STREQUAL "ubuntu"
    AND LINUX_SYSTEM_VERSION_ID STREQUAL "24.04")
 

--- a/third_party/cmake/yaml-cpp.cmake
+++ b/third_party/cmake/yaml-cpp.cmake
@@ -4,16 +4,22 @@
 # SPDX-License-Identifier: MIT
 #
 
+option(ENABLE_YAML_CPP_FROM_SUBMODULE "Force building yaml-cpp from submodule" OFF)
+
 # Try to find system-installed yaml-cpp package
 # Package names vary by distribution:
 # - Fedora/RHEL/openSUSE Tumbleweed: yaml-cpp-devel
 # - Ubuntu/Debian: libyaml-cpp-dev
-find_package(yaml-cpp QUIET)
+if(NOT ENABLE_YAML_CPP_FROM_SUBMODULE)
+  find_package(yaml-cpp QUIET)
+endif()
 
 if(NOT yaml-cpp_FOUND)
   message(STATUS "System yaml-cpp not found, building from submodule")
   set(YAML_CPP_INSTALL OFF)
   set(BUILD_SHARED_LIBS OFF)
+  # Force min CMake ver 3.5 to avoid CMake error on policy CMP0048
+  set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
   add_subdirectory(yaml-cpp EXCLUDE_FROM_ALL)
 endif()
 


### PR DESCRIPTION
Introduce per-dependency CMake options to bypass system package discovery and force building from the bundled submodule:

  - ENABLE_GOOGLETEST_FROM_SUBMODULE
  - ENABLE_LEVEL_ZERO_FROM_SUBMODULE
  - ENABLE_YAML_CPP_FROM_SUBMODULE

When set to ON, the corresponding find_package() call is skipped, causing the build to fall through to the submodule-based build path unconditionally. This is useful when a system-installed version is present but the submodule version is preferred, e.g. for CI reproducibility or version pinning.

All options default to OFF to preserve existing behaviour.