### PR TITLE
UMD: Prevent ResourceCleaner timeout overflow on libstdc++

### DIFF
--- a/umd/level_zero_driver/source/context.cpp
+++ b/umd/level_zero_driver/source/context.cpp
@@ -258,12 +258,17 @@ ResourceCleaner::ResourceCleaner(Context *ctx, std::chrono::milliseconds timeout
     , thread(
           [this](Context *ctx) {
               std::unique_lock<std::mutex> lock(mutex);
-              auto timeout = std::chrono::time_point<std::chrono::steady_clock>::max();
+              const auto noTimeout = std::chrono::time_point<std::chrono::steady_clock>::max();
+              auto timeout = noTimeout;
               while (action != Action::BREAK) {
-                  if (cv.wait_until(lock, timeout) == std::cv_status::timeout) {
+                  if (timeout == noTimeout) {
+                      cv.wait(lock);
+                  } else if (cv.wait_until(lock, timeout) == std::cv_status::timeout) {
                       ctx->releaseMemory();
-                      timeout = std::chrono::time_point<std::chrono::steady_clock>::max();
-                  } else if (action == Action::PRUNE_AFTER_TIMEOUT) {
+                      timeout = noTimeout;
+                      continue;
+                  }
+                  if (action == Action::PRUNE_AFTER_TIMEOUT) {
                       timeout = std::chrono::steady_clock::now() + idleTimeout;
                   }
               }


### PR DESCRIPTION
PR is a copy of https://github.com/intel/linux-npu-driver/pull/142 with extra linting done