### PR TITLE
compiler: Skip linking compiler loader lib on Android builds

### DIFF
--- a/compiler/npu_compiler.cmake
+++ b/compiler/npu_compiler.cmake
@@ -17,11 +17,13 @@ endif()
 message(STATUS "NPU_COMPILER_PACKAGE_DIR: ${NPU_COMPILER_PACKAGE_DIR}")
 target_include_directories(npu_compiler INTERFACE ${NPU_COMPILER_PACKAGE_DIR})
 
-set(NPU_COMPILER_LIBS ${NPU_COMPILER_PACKAGE_DIR}/lib/libopenvino_intel_npu_compiler_loader.so
-                      ${NPU_COMPILER_PACKAGE_DIR}/lib/libopenvino_intel_npu_compiler.so)
 
-# Set the RPATH for the npu_compiler to find the shared library at runtime
-target_link_libraries(npu_compiler INTERFACE ${NPU_COMPILER_LIBS})
+# Skipping the link step on Android to avoid double loading of the compiler shared library
+# because driver loads the compiler at runtime.
+if(NOT ANDROID)
+  # Set the RPATH for the npu_compiler to find the shared library at runtime
+  target_link_libraries(npu_compiler INTERFACE ${NPU_COMPILER_PACKAGE_DIR}/lib/libopenvino_intel_npu_compiler_loader.so)
+endif()
 
 # Bundle TBB only where the distribution does not provide it. On Ubuntu/RHEL
 # libtbb.so.12 is owned by the system libtbb12 package, so shipping a private


### PR DESCRIPTION
Android links ze_intel_npu with npu_compiler, and ze_intel_npu already loads the compiler shared library at runtime. Linking the compiler loader library at build time on Android would cause the compiler shared library to be loaded twice, so this link step is now skipped for Android builds.